### PR TITLE
IIS Express cmd fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gulp-iis-express
 
-> msbuild plugin for [gulp](https://github.com/wearefractal/gulp).
+IIS Express website launcher plugin for [gulp](https://github.com/wearefractal/gulp).
 
 ## Usage
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@
     function gulpIISExpress(config){
 
         if(!config){
-            throw new util.PluginError(PLUGIN_NAME, "Config file is missing!");
+            throw new util.PluginError(PLUGIN_NAME, "Config is missing!");
         }
         if(!config.configFile){
             config.configFile = "";

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@
             config.sysTray = true;
         }
         if(!config.iisExpressPath || config.iisExpressPath == ""){
-            config.iisExpressPath = "C:\\Program Files (x86)\\IIS Express"
+            config.iisExpressPath = process.env.PROGRAMFILES + "\\IIS Express";
         }
         return gulp.src('/index.html')
             .pipe(open('', {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@
         if(!config.browser || config.browser == ""){
             config.browser = "chrome";
         }
+        if(!config.sysTray){
+            config.sysTray = true;
+        }
         if(!config.iisExpressPath || config.iisExpressPath == ""){
             config.iisExpressPath = "C:\\Program Files (x86)\\IIS Express"
         }
@@ -49,6 +52,12 @@
             if(config.configFile !== ""){
                 cmd += '/configFile:"' + config.configFile + '"';
             }
+            
+            if (config.sysTray){
+                cmd += ' /systray:true';
+            }else{
+                cmd += ' /systray:false';
+            }
 
             gulp.src('')
                 .pipe(shell([
@@ -64,6 +73,12 @@
 
             if(config.configFile !== ""){
                 cmd += '/configFile:"' + config.configFile + '"';
+            }
+            
+            if (config.sysTray){
+                cmd += ' /systray:true';
+            }else{
+                cmd += ' /systray:false';
             }
 
             gulp.src('')


### PR DESCRIPTION
- Adds support for /systray flag
- Removes /apppool as this flag is no longer supported
- Adds support for /path based sites (including /port and /clr options)
- Uses `%PROGRAMFILES%` environment variable instead of hard-coding program files directory (can be different between locales and processor architectures)
