### PR TITLE
return empty gulp src in startSites

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@
                 }))
                 .on('error', util.log);
         });
+        return gulp.src('');
     }
     
     //starting an individual site


### PR DESCRIPTION
fixes #4
